### PR TITLE
Using absolute path to panda script

### DIFF
--- a/lib/Panda/Fetcher.pm
+++ b/lib/Panda/Fetcher.pm
@@ -34,7 +34,7 @@ class Panda::Fetcher does Pies::Fetcher {
                         and die $p, "Failed updating the repo";
                     };
                 } else {
-                    shell "git clone -q $url $dest"
+                    shell "git clone -q $url \"$dest\""
                         and die $p, "Failed cloning the repo";
                 }
 


### PR DESCRIPTION
Using the path where panda.bat is to look for panda itself. Otherwise you have to chdir to rakudo/bin to run panda.bat.
