### PR TITLE
don't explode when no lib folder exists +test

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -53,9 +53,12 @@ sub build-order(@module-files) {
 
 method build($where) {
     indir $where, {
-        my @files = find(dir => 'lib', type => 'file').grep({
-            $_.name.substr(0, 1) ne '.'
-        });
+        my @files;
+        if 'lib'.IO.d { 
+            @files = find(dir => 'lib', type => 'file').grep({
+                $_.name.substr(0, 1) ne '.'
+            });
+        }
         if "Build.pm".IO.f {
             @*INC.push('.');
             require 'Build.pm';

--- a/t/builder.t
+++ b/t/builder.t
@@ -2,7 +2,7 @@ use Test;
 use Panda::Builder;
 use Shell::Command;
 
-plan 6;
+plan 7;
 
 my $srcdir = 'testmodules';
 
@@ -14,6 +14,8 @@ ok "$srcdir/dummymodule/blib/lib/manual.pod".IO ~~  :f, 'pod copied too';
 ok "$srcdir/dummymodule/blib/lib/bar.pir".IO !~~ :f, 'pod not compiled';
 ok "$srcdir/dummymodule/blib/lib/foo.js".IO ~~ :f,
    'random files also copied to blib';
+
+lives_ok { Panda::Builder.build("$srcdir/testme1") };
 
 rm_rf "$srcdir/dummymodule/blib";
 


### PR DESCRIPTION
makes at least ufo work again; Task::Star was not installable before it seems.
