### PR TITLE
Use temp CWD instead of chdir. Avoids LexoticException.

### DIFF
--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -6,10 +6,8 @@ sub dirname ($mod as Str) is export {
 }
 
 sub indir (Str $where, Callable $what) is export {
-    my $old = cwd;
-    LEAVE chdir $old;
     mkpath $where;
-    chdir $where;
+    temp $*CWD = IO::Spec.rel2abs($where);
     $what()
 }
 


### PR DESCRIPTION
Requires latest rakudo with https://github.com/rakudo/rakudo/commit/efac451801
