### PR TITLE
use $*EXECUTABLE_NAME instead of hard-coded 'perl6'

### DIFF
--- a/bootstrap.pl
+++ b/bootstrap.pl
@@ -44,7 +44,7 @@ my $env_sep = $is_win ?? ';' !! ':';
 %*ENV<PERL6LIB> ~= "{$env_sep}{cwd}/ext/JSON__Tiny/lib";
 %*ENV<PERL6LIB> ~= "{$env_sep}{cwd}/lib";
 
-shell "perl6 bin/panda install File::Find Shell::Command JSON::Tiny {cwd}";
+shell "$*EXECUTABLE_NAME bin/panda install File::Find Shell::Command JSON::Tiny {cwd}";
 if "$destdir/panda/src".IO ~~ :d {
     rm_rf "$destdir/panda/src"; # XXX This shouldn't be necessary, I think
                                 # that src should not be kept at all, but

--- a/rebootstrap.pl
+++ b/rebootstrap.pl
@@ -19,7 +19,7 @@ for grep(*.defined, %*ENV<DESTDIR>, %*CUSTOM_LIB<site home>) {
 
 if not $state-file.defined {
     say "No need to rebootstrap, running normal bootstrap";
-    shell 'perl6 bootstrap.pl';
+    shell "$*EXECUTABLE_NAME bootstrap.pl";
     exit 0;
 }
 
@@ -44,9 +44,9 @@ given open($state-file) {
 # and reinstall all manually-installed modules
 rm_rf "$prefix/lib";
 rm_rf "$prefix/panda";
-shell 'perl6 bootstrap.pl';
+shell "$*EXECUTABLE_NAME bootstrap.pl";
 say "==> Reinstalling @modules[]";
-shell "perl6 bin/panda install @modules[]";
+shell "$*EXECUTABLE_NAME bin/panda install @modules[]";
 
 # Save the backup state file back to $prefix/panda/
 spurt "$state-file.bak", $old-state if $old-state;


### PR DESCRIPTION
Because we now have perl6-p and perl6-j binaries.
