### PR TITLE
compile to pir AFTER installation

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -78,16 +78,6 @@ method build($where) {
                 next unless $file ~~ /\.pm6?$/;
                 my $dest = "blib/{$file.directory}/"
                          ~ "{$file.basename.subst(/\.pm6?$/, ".{compsuffix}" )}";
-                #note "$dest modified: ", $dest.IO.modified;
-                #note "$file modified: ", $file.IO.modified;
-                #if $dest.IO.modified >= $file.IO.modified {
-                #    say "$file already compiled, skipping";
-                #    next;
-                #}
-                say "Compiling $file to {compsuffix}";
-                shell "$*EXECUTABLE_NAME --target={compsuffix} "
-                    ~ "--output=$dest $file"
-                        or fail "Failed building $file";
             }
             1;
         }

--- a/t/builder.t
+++ b/t/builder.t
@@ -3,13 +3,12 @@ use Panda::Common;
 use Panda::Builder;
 use Shell::Command;
 
-plan 7;
+plan 6;
 
 my $srcdir = 'testmodules';
 
 lives_ok { Panda::Builder.build("$srcdir/dummymodule") };
 
-ok "$srcdir/dummymodule/blib/lib/foo.{compsuffix}".IO ~~  :f, 'module compiled';
 ok "$srcdir/dummymodule/blib/lib/foo.pm".IO ~~   :f, 'and opied to blib';
 ok "$srcdir/dummymodule/blib/lib/manual.pod".IO ~~  :f, 'pod copied too';
 ok "$srcdir/dummymodule/blib/lib/bar.{compsuffix}".IO !~~ :f, 'pod not compiled';

--- a/t/installer.t
+++ b/t/installer.t
@@ -15,7 +15,7 @@ sub file_exists_ok($a as Str, $msg as Str) {
 }
 
 file_exists_ok "$dest/lib/foo.pm", 'module installed';
-file_exists_ok "$dest/lib/foo.{compsuffix}",  "{compsuffix} installed";
+file_exists_ok "$dest/lib/foo.{compsuffix}", 'module compiled';
 file_exists_ok "$dest/lib/bar.pod", 'pod installed';
 file_exists_ok "$dest/lib/baz.js", 'random files installed';
 file_exists_ok "$dest/bin/bar", 'bin installed';


### PR DESCRIPTION
Hi,

currently panda compiles .pm to .pir inside .work directory which is only a staging directory. This may cause issues if some logic in a module is done during compile time, data found during compile time is embedded into .pir.

This change set moves .pir generation to the install step.