### PR TITLE
use absolute paths where possible [based on moar-support branch]

### DIFF
--- a/bin/panda-build
+++ b/bin/panda-build
@@ -2,5 +2,5 @@
 use Panda::Builder;
 
 sub MAIN($where = '.') {
-    Panda::Builder.build($where);
+    Panda::Builder.build($where.path.absolute);
 }

--- a/bin/panda-fetch
+++ b/bin/panda-fetch
@@ -6,5 +6,5 @@ sub MAIN($from, $to? is copy) {
         note "Fetching to ./work";
         $to = 'work';
     }
-    Panda::Fetcher.fetch($from, $to);
+    Panda::Fetcher.fetch($from.path.absolute, $to.path.absolute);
 }

--- a/bin/panda-install
+++ b/bin/panda-install
@@ -2,5 +2,5 @@
 use Panda::Installer;
 
 sub MAIN($from = '.', $to?) {
-    Panda::Installer.new.install($from, $to);
+    Panda::Installer.new.install($from.path.absolute, $to);
 }

--- a/bin/panda-test
+++ b/bin/panda-test
@@ -2,5 +2,5 @@
 use Panda::Tester;
 
 sub MAIN($where = '.') {
-    Panda::Tester.test($where);
+    Panda::Tester.test($where.path.absolute);
 }

--- a/bin/redpanda
+++ b/bin/redpanda
@@ -27,7 +27,7 @@ sub get-meta($module is copy) {
 }
 
 sub MAIN($url) {
-    my $dir = '.work';
+    my $dir = '.work'.path.absolute;
     rm_rf $dir;
     try {
         Panda::Fetcher::fetch($url, $dir);

--- a/lib/Panda.pm
+++ b/lib/Panda.pm
@@ -9,7 +9,7 @@ use JSON::Tiny;
 
 sub tmpdir {
     state $i = 0;
-    ".work/{time}_{$i++}"
+    ".work/{time}_{$i++}".path.absolute
 }
 
 class Panda {

--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -5,9 +5,9 @@ sub dirname ($mod as Str) is export {
     $mod.subst(':', '_', :g);
 }
 
-sub indir (Str $where, Callable $what) is export {
+sub indir ($where, Callable $what) is export {
     mkpath $where;
-    temp $*CWD = IO::Spec.rel2abs($where);
+    temp $*CWD = $where.path.absolute;
     $what()
 }
 


### PR DESCRIPTION
This solves issues where we collect the current working directory, chdir to it and pass then the outdated relative path to a custom Panda::Builder's build method.
