### PR TITLE
Remove old Build class when using Build.pm

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -56,6 +56,7 @@ method build($where) {
     indir $where, {
         if "Build.pm".IO.f {
             @*INC.push('.');
+            GLOBAL::<Build>:delete;
             require 'Build.pm';
             if ::('Build').isa(Panda::Builder) {
                 ::('Build').new.build($where);


### PR DESCRIPTION
If two packages with Build.pm files were installed during the same panda
run (example: "panda install MIME::Base64 Auth::PAM::Simple"), the
second and subsequent packages would all fail to build, as the Build
class already existed when the Build.pm file attempted to create it.
