### PR TITLE
Allow non-ecosystem dependencies

### DIFF
--- a/lib/Panda/Ecosystem.pm
+++ b/lib/Panda/Ecosystem.pm
@@ -37,9 +37,20 @@ class Panda::Ecosystem {
         unless defined $list {
             die "An unknown error occured while reading the projects file";
         }
+        my %non-ecosystem = %!saved-meta;
         for $list.list -> $mod {
             my $p = Panda::Project.new(
                 name         => $mod<name>,
+                version      => $mod<version>,
+                dependencies => $mod<depends>,
+                metainfo     => $mod,
+            );
+            self.add-project($p);
+            %non-ecosystem{$mod<name>}:delete;
+        }
+        for %non-ecosystem.kv -> $name, $mod {
+            my $p = Panda::Project.new(
+                name         => $name,
                 version      => $mod<version>,
                 dependencies => $mod<depends>,
                 metainfo     => $mod,


### PR DESCRIPTION
If a module is installed, we can now use it as a dependency without
needing it in the ecosystem. This allows you to use panda to install
private modules that never see the ecosystem, or to test a set of
modules before adding them to the ecosystem.
