### PR TITLE
Track change in $*VM name access

### DIFF
--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -30,13 +30,13 @@ sub withp6lib(&what) is export {
 }
 
 sub compsuffix is export {
-    $*VM<name> eq 'moar'
+    $*VM.name eq 'moar'
         ?? 'moarvm'
         !! comptarget
 }
 
 sub comptarget is export {
-    given $*VM<name> {
+    given $*VM.name {
         when 'parrot' {
             return 'pir';
         }


### PR DESCRIPTION
Tiny tweak to accommodate changes in $*VM. Probably not the last!
