### PR TITLE
Fix deprecated use of $*VM<name>

### DIFF
--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -30,13 +30,13 @@ sub withp6lib(&what) is export {
 }
 
 sub compsuffix is export {
-    $*VM<name> eq 'moar'
+    $*VM.name eq 'moar'
         ?? 'moarvm'
         !! comptarget
 }
 
 sub comptarget is export {
-    given $*VM<name> {
+    given $*VM.name {
         when 'parrot' {
             return 'pir';
         }


### PR DESCRIPTION
Try to fix 

$*VM<name> called at:
  lib/Panda/Common.pm, lines 33,39
