### PR TITLE
Don't install deps when just 'look'ing

### DIFF
--- a/bin/panda
+++ b/bin/panda
@@ -47,7 +47,7 @@ multi MAIN ('search', $pattern) {
 multi MAIN ('look', *@modules) {
     for @modules -> $x {
         try {
-            $panda.resolve($x, :notests, :action<look>);
+            $panda.resolve($x, :notests, :nodeps, :action<look>);
             CATCH { when X::Panda { say $_.message } }
         };
     }


### PR DESCRIPTION
Refinement to last PR. Set :nodeps flag to stop panda installing dependent modules when just looking.
