### PR TITLE
Builder.pm: Ignore Pod when determining module dependencies.

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -35,27 +35,27 @@ sub strip-pod(@in is rw, Str :$in-block? = '') {
     my $in-para = False;
     while @in.elems {
         my $line = @in.shift;
+
         if $in-para && $line ~~ /^\s*$/ {
+            # End of paragraph
             $in-para = False;
             @out.push: $line;
             next;
         }
-        if $in-block && $line ~~ /^\s* \=end $in-block / {
+        if $in-block && $line ~~ /^\s* '=end' \s* $in-block / {
+            # End of block
             @out.push: '';
             last;
         }
 
-        if $line ~~ /^\s* \=begin \s* ([\w\-]+)/ && $0 -> $block-type {
+        if $line ~~ /^\s* '=begin' \s+ (<[\w\-]>+)/ && $0 -> $block-type {
+            # Start of block
             $in-para = False;
             @out.push: '', |strip-pod(@in, :in-block($block-type.Str));
             next;
         }
-        if $line ~~ /^\s* \=for \s* [\w\-]+/ {
-            $in-para = True;
-            @out.push: '';
-            next;
-        }
-        if $line ~~ /^\s* \=\w+(\s|$)/ {
+        if $line ~~ /^\s* '='\w<[\w-]>* (\s|$)/ {
+            # Start of paragraph
             $in-para = True;
             @out.push: '';
             next;


### PR DESCRIPTION
Ignore use/need/require statements inside Pod blocks when determining module dependencies in build-order().

_Justification_: my [`Net::Packet`](https://github.com/jpve/perl6-net-packet) module fails to install because `use` statements inside Pod documentation were added to the dependency list of a module. 
