### PR TITLE
Make .bat file work with powershell as well as cmd

### DIFF
--- a/bin/panda.bat
+++ b/bin/panda.bat
@@ -4,7 +4,7 @@ if "%OS%" == "Windows_NT" goto WinNT
 perl6 "%~dp0\%0" %1 %2 %3 %4 %5 %6 %7 %8 %9
 goto endofperl
 :WinNT
-perl6 "%~dp0\%0" %*
+perl6 "%~dp0\%~n0" %*
 if NOT "%COMSPEC%" == "%SystemRoot%\system32\cmd.exe" goto endofperl
 if %errorlevel% == 9009 echo You do not have Perl in your PATH.
 if errorlevel 1 goto script_failed_so_exit_with_non_zero_val 2>nul


### PR DESCRIPTION
In powershell, %0 drops in the full path to the file, so we use %~n0 to just drop in the filename portion. This works in both powershell as well as cmd
