### PR TITLE
capture prove stderr output

### DIFF
--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -17,7 +17,7 @@ method test($where, :$bone, :$prove-command = 'prove') {
 
         if $run-default && 't'.IO ~~ :d {
             withp6lib {
-                my $cmd    = "$prove-command -e $*EXECUTABLE -r t/";
+                my $cmd    = "$prove-command -e $*EXECUTABLE -r t/ 2>&1";
                 my $handle = pipe($cmd, :r);
                 my $output = '';
                 for $handle.lines {


### PR DESCRIPTION
This makes the reports on testers.perl6.org more informative.

`2>&1` is less than ideal since it's dependent on the shell etc, but I don't know if there's any other way at the moment..
