### PR TITLE
capture build stage stderr output

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -128,7 +128,7 @@ method build($where, :$bone) {
                 my $cmd    = "$*EXECUTABLE --target={comptarget} "
                            ~ "--output=$dest $file";
                 $output ~= "$cmd\n";
-                my $handle = pipe($cmd, :r);
+                my $handle = pipe("$cmd 2>&1", :r);
                 for $handle.lines {
                     .chars && .say;
                     $output ~= "$_\n";

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -17,8 +17,8 @@ method test($where, :$bone, :$prove-command = 'prove') {
 
         if $run-default && 't'.IO ~~ :d {
             withp6lib {
-                my $cmd    = "$prove-command -e $*EXECUTABLE -r t/ 2>&1";
-                my $handle = pipe($cmd, :r);
+                my $cmd    = "$prove-command -e $*EXECUTABLE -r t/";
+                my $handle = pipe("$cmd 2>&1", :r);
                 my $output = '';
                 for $handle.lines {
                     .chars && .say;


### PR DESCRIPTION
Also, move 2>&1 workaround inside the pipe call. ref tadzik/panda#126
