### PR TITLE
Add a way to specify a particular commit in URLs

### DIFF
--- a/lib/Panda/Fetcher.pm
+++ b/lib/Panda/Fetcher.pm
@@ -36,7 +36,7 @@ method fetch($from, $to) {
     return True;
 }
 
-sub git-fetch($from, $to, $commit = Nil) {
+sub git-fetch($from, $to, $commit?) {
     shell "git clone -q $from \"$to\""
         or fail "Failed cloning git repository '$from'";
     if $commit {


### PR DESCRIPTION
Since the HEAD of a repo may be where development happens and a
particular tag or commit will correspond to a particular version of a
module, allow URLS of the form  git://github.com/foo/bar@v1.2.3
to checkout the commit specified by "v1.2.3" once the repo is cloned.