### PR TITLE
handle malformed JSON project file case error handling better

### DIFF
--- a/lib/Panda/Ecosystem.pm
+++ b/lib/Panda/Ecosystem.pm
@@ -33,9 +33,14 @@ class Panda::Ecosystem {
         }
 
         self.update if $!projectsfile.IO !~~ :f || $!projectsfile.IO ~~ :z;
-        my $list = from-json slurp $!projectsfile;
-        unless defined $list {
-            die "An unknown error occured while reading the projects file";
+        my $list;
+        {
+            $list = from-json slurp $!projectsfile;
+            die unless defined $list;
+
+            CATCH {
+                die "An unknown error occured while reading the projects file";
+            }
         }
         my %non-ecosystem = %!saved-meta;
         for $list.list -> $mod {


### PR DESCRIPTION
UK Virgin ISP has blocked p6c.org (which I will complain about).  This patch gives a better error message in this case.