### PR TITLE
Allow a '\' character for local installs

### DIFF
--- a/lib/Panda.pm
+++ b/lib/Panda.pm
@@ -52,7 +52,7 @@ class Panda {
 
     method project-from-local($proj as Str) {
         if $proj.IO ~~ :d and "$proj/META.info".IO ~~ :f {
-            if $proj !~~ rx{'/'|'.'} {
+            if $proj !~~ rx{'/'|'.'|'\\'} {
                 die X::Panda.new($proj, 'resolve',
                         "Possibly ambiguous module name requested." 
                         ~ " Please specify at least one slash if you really mean to install"


### PR DESCRIPTION
This fixes panda bootstrap on windows.