### PR TITLE
Restore testing lib order blib/lib, then lib

### DIFF
--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -17,7 +17,7 @@ method test($where, :$bone, :$prove-command = 'prove') {
 
         if $run-default && 't'.IO ~~ :d {
             withp6lib {
-                my $cmd    = "$prove-command -e \"$*EXECUTABLE -Ilib\" -r t/";
+                my $cmd    = "$prove-command -e \"$*EXECUTABLE -Iblib/lib -Ilib\" -r t/";
 
                 my $handle = pipe("$cmd 2>&1", :r);
                 my $output = '';


### PR DESCRIPTION
commit 7c2c196 added `-Ilib` to the prove command line. As a side affect, `lib` is currently being searched before `blib/lib`; so that Panda is currently testing against uncompiled sources.

I've also added `-Iblib/lib` which is hopefully closer to the original behavior.