### PR TITLE
Unlink destination before performing copy on non-Windows

### DIFF
--- a/lib/Panda/Installer.pm
+++ b/lib/Panda/Installer.pm
@@ -28,6 +28,9 @@ method default-destdir {
 
 sub copy($src, $dest) {
     note "Copying $src to $dest";
+    unless $*DISTRO.is-win {
+        $dest.IO.unlink;
+    }
     $src.copy($dest);
 }
 


### PR DESCRIPTION
MoarVM uses `mmap()` to map bytecode files into memory.  Unfortunately,
this means that if a process overwrites the contents of that bytecode
file during the operation of a Perl 6 program using it (for example,
Panda updating its own dependencies), the memory map will seemingly
change out from under MoarVM, usually resulting in a crash.  Unlinking
the destination first doesn't harm processes that have loaded that
bytecode; it just guarantees that the new version gets its own inode
and doesn't mess with currently running Perl 6 processes.

Note that this is non-atomic, so a Perl 6 process started at just
the wrong time will try to open the bytecode file between the unlinking
and the creation of the copy, or worse yet, open and use the file
while it's being written.  The risk of this is low enough where this
shouldn't be a problem, and could easily be mitigated in the future
using `rename()`.

This change doesn't happen for Windows, mainly because I don't know
how Windows responds to files being removed while other processes have
them open.  jnthn tells me this will result in an access violation,
so a Windows-specific fix is still necessary.  However, perhaps no
fix is necessary on Windows at all.