### PR TITLE
work around for #165: panda install DBIish: Cannot invoke null object

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -40,7 +40,12 @@ sub strip-pod(@in is rw, Str :$in-block? = '') {
             next;
         }
 
-        @out.push: ($in-para || $in-block) ?? '' !! $line;
+        if $in-para || $in-block {
+            @out.push: '';
+        }
+        else {
+            @out.push: $line;
+        }
     }
     @out;
 }


### PR DESCRIPTION
This ternary expression seems to be part of the recipe for triggering this rakudobug. Replaced it with an if/then/else.