### PR TITLE
Replace .for method with .flatmap

### DIFF
--- a/lib/Panda/App.pm
+++ b/lib/Panda/App.pm
@@ -48,10 +48,10 @@ sub listprojects($panda, :$installed, :$verbose) is export {
     my @projects  = $es.project-list.sort(*.name);
        @projects .= grep({ $es.project-get-state($_) ne Panda::Project::State::absent })
                     if $installed;
-    my @saved     = @projects.for({ $es.project-get-saved-meta($_) || {} });
+    my @saved     = @projects.flatmap({ $es.project-get-saved-meta($_) || {} });
     my $max-name  = @projects».name».chars.max;
     my $max-ver   = @projects».version».chars.max;
-    my $max-rev   = @saved.for({ $_<source-revision> // '?'})».chars.max;
+    my $max-rev   = @saved.flatmap({ $_<source-revision> // '?'})».chars.max;
 
     for @projects -> $x {
         my $s = do given $es.project-get-state($x) {


### PR DESCRIPTION
The `.for` method has been deprecated in favour of the `.flatmap` method.
The deprecated method will be removed in Rakudo 2015.09.  This change
removes the deprecation warning that appears when running the 'list'
command.