### PR TITLE
Dont cross the streams - Proc::Async

### DIFF
--- a/lib/Panda/Project.pm
+++ b/lib/Panda/Project.pm
@@ -5,8 +5,12 @@ class Panda::Project {
     has %.metainfo;
 
     has $.build-output is rw;
+    has $.build-stdout is rw;
+    has $.build-stderr is rw;
     has $.build-passed is rw;
     has $.test-output is rw;
+    has $.test-stdout is rw;
+    has $.test-stderr is rw;
     has $.test-passed is rw;
 
     enum State <absent installed-dep installed>;


### PR DESCRIPTION
This is another attempt at separating the standard output and error of a build.

This keeps both streams interleaved and preserves existing behavior, but also offers separate stdout and stderr attributes for tools to use.