### PR TITLE
Remove ANSI terminal color codes

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -116,7 +116,7 @@ method build($where, :$bone) {
                     $stdout ~= $chunk;
                 });
                 $proc.stderr.tap(-> $chunk {
-                    print "\e[31;1m$chunk\e[0m";
+                    print $chunk;
                     $output ~= $chunk;
                     $stderr ~= $chunk;
                 });


### PR DESCRIPTION
This is something I was using for testing, and is not portable.