### PR TITLE
Somewhat repaired gen-meta

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -110,8 +110,8 @@ method build($where, :$bone, :$deps) {
 
                 my @pargs = [ "--target={comptarget}", "--output=$dest", $file ]<>;
 
-                if $deps {
-                    @pargs.unshift: "-MPanda::DepTracker";
+                for $deps -> $dep {
+                    @pargs.unshift: "-M" ~ $dep;
                 }
 
                 my $proc = Proc::Async.new($*EXECUTABLE, @pargs);

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -48,7 +48,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
         try unlink %*ENV<PANDA_PROTRACKER_FILE> if %*ENV<PANDA_PROTRACKER_FILE>.IO.e;
 
         $panda.announce('building', $bone);
-        unless $_ = $panda.builder.build($dir, :deps) {
+        unless $_ = $panda.builder.build($dir, :deps(['Panda::DepTracker'])) {
             die X::Panda.new($bone.name, 'build', $_)
         }
 
@@ -82,7 +82,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
 
         unless $notests {
             $panda.announce('testing', $bone);
-            unless $_ = $panda.tester.test($dir, :deps) {
+            unless $_ = $panda.tester.test($dir, :deps(['Panda::DepTracker'])) {
                 die X::Panda.new($bone.name, 'test', $_)
             }
             if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e {

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -41,14 +41,14 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
 
     my $perl6_exe = $*EXECUTABLE;
     try {
-        my $*EXECUTABLE              = "$perl6_exe -MPanda::DepTracker";
+        my $*EXECUTABLE              = $perl6_exe;
         %*ENV<PANDA_DEPTRACKER_FILE> = "$dir/deptracker-build-$*PID";
         %*ENV<PANDA_PROTRACKER_FILE> = "$dir/protracker-build-$*PID";
         try unlink %*ENV<PANDA_DEPTRACKER_FILE> if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e;
         try unlink %*ENV<PANDA_PROTRACKER_FILE> if %*ENV<PANDA_PROTRACKER_FILE>.IO.e;
 
         $panda.announce('building', $bone);
-        unless $_ = $panda.builder.build($dir) {
+        unless $_ = $panda.builder.build($dir, :deps) {
             die X::Panda.new($bone.name, 'build', $_)
         }
 

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -82,7 +82,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
 
         unless $notests {
             $panda.announce('testing', $bone);
-            unless $_ = $panda.tester.test($dir) {
+            unless $_ = $panda.tester.test($dir, :deps) {
                 die X::Panda.new($bone.name, 'test', $_)
             }
             if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e {

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -21,8 +21,13 @@ method test($where, :$bone, :$prove-command = 'prove', :$deps) {
                 my $stdout = '';
                 my $stderr = '';
 
-                my $p6command = $deps ?? "$*EXECUTABLE -MPanda::DepTracker" !! $*EXECUTABLE;
-                my $proc = Proc::Async.new($prove-command, '-e', "$p6command -Ilib", '-r', 't/');
+                my $libs = '';
+
+                for $deps -> $lib {
+                    $libs ~= ' -M' ~ $lib;
+                }
+
+                my $proc = Proc::Async.new($prove-command, '-e', "$*EXECUTABLE $libs -Ilib", '-r', 't/');
                 $proc.stdout.tap(-> $chunk {
                     print $chunk;
                     $output ~= $chunk;

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -1,7 +1,7 @@
 class Panda::Tester {
 use Panda::Common;
 
-method test($where, :$bone, :$prove-command = 'prove') {
+method test($where, :$bone, :$prove-command = 'prove', :$deps) {
     indir $where, {
         my Bool $run-default = True;
         if "Build.pm".IO.f {
@@ -21,7 +21,8 @@ method test($where, :$bone, :$prove-command = 'prove') {
                 my $stdout = '';
                 my $stderr = '';
 
-                my $proc = Proc::Async.new($prove-command, '-e', "$*EXECUTABLE -Ilib", '-r', 't/');
+                my $p6command = $deps ?? "$*EXECUTABLE -MPanda::DepTracker" !! $*EXECUTABLE;
+                my $proc = Proc::Async.new($prove-command, '-e', "$p6command -Ilib", '-r', 't/');
                 $proc.stdout.tap(-> $chunk {
                     print $chunk;
                     $output ~= $chunk;


### PR DESCRIPTION
Somewhere along the line it was trying to pass "$*EXECUTABLE -MPanda::DepTracker" to Proc::Async.new when building as part of "gen-meta" . This clearly doesn't work.  

This adds a new named param to build so that the DepTracker can be added when required.

I may have to add this in a number of places at it seems to depend on the previous behaviour of setting $*EXECUTABLE with the '-M' all over the place.