### PR TITLE
Repair "gen-meta" (again)

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -68,7 +68,7 @@ sub build-order(@module-files) {
     return map { %module-to-path{$_} }, @order;
 }
 
-method build($where, :$bone) {
+method build($where, :$bone, :@deps) {
     indir $where, {
         if "Build.pm".IO.f {
             @*INC.push("file#$where");   # TEMPORARY !!!
@@ -108,7 +108,13 @@ method build($where, :$bone) {
                 #}
                 say "Compiling $file to {comptarget}";
 
-                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($*EXECUTABLE, "--target={comptarget}", "--output=$dest", $file);
+                my @pargs = "--target={comptarget}", "--output=$dest", $file;
+
+                for @deps -> $dep {
+                    @pargs.unshift: "-M" ~ $dep;
+                }
+
+                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($*EXECUTABLE, @pargs);
 
                 if $bone {
                     $bone.build-output = $output;

--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -68,7 +68,7 @@ sub build-order(@module-files) {
     return map { %module-to-path{$_} }, @order;
 }
 
-method build($where, :$bone, :$deps) {
+method build($where, :$bone, :@deps) {
     indir $where, {
         if "Build.pm".IO.f {
             @*INC.push("file#$where");   # TEMPORARY !!!
@@ -110,7 +110,7 @@ method build($where, :$bone, :$deps) {
 
                 my @pargs = [ "--target={comptarget}", "--output=$dest", $file ]<>;
 
-                for $deps -> $dep {
+                for @deps -> $dep {
                     @pargs.unshift: "-M" ~ $dep;
                 }
 

--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -110,8 +110,8 @@ method build($where, :$bone, :$deps) {
 
                 my @pargs = [ "--target={comptarget}", "--output=$dest", $file ]<>;
 
-                if $deps {
-                    @pargs.unshift: "-MPanda::DepTracker";
+                for $deps -> $dep {
+                    @pargs.unshift: "-M" ~ $dep;
                 }
 
                 my $proc = Proc::Async.new($*EXECUTABLE, @pargs);

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -48,7 +48,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
         try unlink %*ENV<PANDA_PROTRACKER_FILE> if %*ENV<PANDA_PROTRACKER_FILE>.IO.e;
 
         $panda.announce('building', $bone);
-        unless $_ = $panda.builder.build($dir, :deps) {
+        unless $_ = $panda.builder.build($dir, :deps(['Panda::DepTracker'])) {
             die X::Panda.new($bone.name, 'build', $_)
         }
 
@@ -82,7 +82,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
 
         unless $notests {
             $panda.announce('testing', $bone);
-            unless $_ = $panda.tester.test($dir, :deps) {
+            unless $_ = $panda.tester.test($dir, :deps(['Panda::DepTracker'])) {
                 die X::Panda.new($bone.name, 'test', $_)
             }
             if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e {

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -41,14 +41,14 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
 
     my $perl6_exe = $*EXECUTABLE;
     try {
-        my $*EXECUTABLE              = "$perl6_exe -MPanda::DepTracker";
+        my $*EXECUTABLE              = $perl6_exe;
         %*ENV<PANDA_DEPTRACKER_FILE> = "$dir/deptracker-build-$*PID";
         %*ENV<PANDA_PROTRACKER_FILE> = "$dir/protracker-build-$*PID";
         try unlink %*ENV<PANDA_DEPTRACKER_FILE> if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e;
         try unlink %*ENV<PANDA_PROTRACKER_FILE> if %*ENV<PANDA_PROTRACKER_FILE>.IO.e;
 
         $panda.announce('building', $bone);
-        unless $_ = $panda.builder.build($dir) {
+        unless $_ = $panda.builder.build($dir, :deps) {
             die X::Panda.new($bone.name, 'build', $_)
         }
 

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -82,7 +82,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
 
         unless $notests {
             $panda.announce('testing', $bone);
-            unless $_ = $panda.tester.test($dir) {
+            unless $_ = $panda.tester.test($dir, :deps) {
                 die X::Panda.new($bone.name, 'test', $_)
             }
             if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e {

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -1,7 +1,7 @@
 class Panda::Tester {
 use Panda::Common;
 
-method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'prove.bat' !! 'prove', $deps) {
+method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'prove.bat' !! 'prove', :@deps) {
     indir $where, {
         my Bool $run-default = True;
         if "Build.pm".IO.f {
@@ -23,7 +23,7 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
 
                 my $libs = '';
 
-                for $deps -> $lib {
+                for @deps -> $lib {
                     $libs ~= ' -M' ~ $lib;
                 }
 

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -21,8 +21,13 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
                 my $stdout = '';
                 my $stderr = '';
 
-                my $p6command = $deps ?? "$*EXECUTABLE -MPanda::DepTracker" !! $*EXECUTABLE;
-                my $proc = Proc::Async.new($prove-command, '-e', "$p6command -Ilib", '-r', 't/');
+                my $libs = '';
+
+                for $deps -> $lib {
+                    $libs ~= ' -M' ~ $lib;
+                }
+
+                my $proc = Proc::Async.new($prove-command, '-e', "$*EXECUTABLE $libs -Ilib", '-r', 't/');
                 $proc.stdout.tap(-> $chunk {
                     print $chunk;
                     $output ~= $chunk;

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -1,7 +1,7 @@
 class Panda::Tester {
 use Panda::Common;
 
-method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'prove.bat' !! 'prove') {
+method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'prove.bat' !! 'prove', :@deps) {
     indir $where, {
         my Bool $run-default = True;
         if "Build.pm".IO.f {
@@ -17,7 +17,11 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
 
         if $run-default && 't'.IO ~~ :d {
             withp6lib {
-                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($prove-command, '-e', "$*EXECUTABLE -Ilib", '-r', 't/');
+                my $libs = '';
+                for @deps -> $lib {
+                    $libs ~= ' -M' ~ $lib;
+                }
+                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($prove-command, '-e', "$*EXECUTABLE $libs -Ilib", '-r', 't/');
 
                 if $bone {
                     $bone.test-output = $output;

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -1,7 +1,7 @@
 class Panda::Tester {
 use Panda::Common;
 
-method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'prove.bat' !! 'prove') {
+method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'prove.bat' !! 'prove', $deps) {
     indir $where, {
         my Bool $run-default = True;
         if "Build.pm".IO.f {
@@ -21,7 +21,8 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
                 my $stdout = '';
                 my $stderr = '';
 
-                my $proc = Proc::Async.new($prove-command, '-e', "$*EXECUTABLE -Ilib", '-r', 't/');
+                my $p6command = $deps ?? "$*EXECUTABLE -MPanda::DepTracker" !! $*EXECUTABLE;
+                my $proc = Proc::Async.new($prove-command, '-e', "$p6command -Ilib", '-r', 't/');
                 $proc.stdout.tap(-> $chunk {
                     print $chunk;
                     $output ~= $chunk;


### PR DESCRIPTION
When the change to use Proc::Async was made it didn't take into account that Panda::Bundler was setting $*EXECUTABLE to add the -MPanda::DepTracker and this was being passed directly to Proc::Async as the command which doesn't work.

This adds a :@deps argument to Panda::Builder.build and Panda::Tester.test that allows the caller to specify a list of modules that should be loaded with '-M'  and Panda::Bundler.bundle passes Panda::DepTracker.

This is a rework of  #184 which didn't merge cleanly with the current state of master/HEAD