### PR TITLE
Fall back to shell() if Proc::Async is not available

### DIFF
--- a/lib/Panda/Builder.pm
+++ b/lib/Panda/Builder.pm
@@ -108,21 +108,7 @@ method build($where, :$bone) {
                 #}
                 say "Compiling $file to {comptarget}";
 
-                my $proc = Proc::Async.new($*EXECUTABLE, "--target={comptarget}", "--output=$dest", $file);
-                $output ~= "$*EXECUTABLE --target={comptarget} --output=$dest $file\n";
-                $proc.stdout.tap(-> $chunk {
-                    print $chunk;
-                    $output ~= $chunk;
-                    $stdout ~= $chunk;
-                });
-                $proc.stderr.tap(-> $chunk {
-                    print $chunk;
-                    $output ~= $chunk;
-                    $stderr ~= $chunk;
-                });
-                my $p = $proc.start;
-
-                my $passed = $p.result.exitcode == 0;
+                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($*EXECUTABLE, "--target={comptarget}", "--output=$dest", $file);
 
                 if $bone {
                     $bone.build-output = $output;

--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -73,6 +73,28 @@ class X::Panda is Exception {
     }
 }
 
+sub run-and-gather-output(*@command) is export {
+    my $output = '';
+    my $stdout = '';
+    my $stderr = '';
+
+    my $proc = Proc::Async.new(|@command);
+    $proc.stdout.tap(-> $chunk {
+        print $chunk;
+        $output ~= $chunk;
+        $stdout ~= $chunk;
+    });
+    $proc.stderr.tap(-> $chunk {
+        print $chunk;
+        $output ~= $chunk;
+        $stderr ~= $chunk;
+    });
+    my $p = $proc.start;
+    my $passed = $p.result.exitcode == 0;
+
+    :$output, :$stdout, :$stderr, :$passed
+}
+
 }
 
 # vim: ft=perl6

--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -73,24 +73,40 @@ class X::Panda is Exception {
     }
 }
 
+my $has-proc-async = Proc::<Async>:exists;
+
 sub run-and-gather-output(*@command) is export {
     my $output = '';
     my $stdout = '';
     my $stderr = '';
+    my $passed;
 
-    my $proc = Proc::Async.new(|@command);
-    $proc.stdout.tap(-> $chunk {
-        print $chunk;
-        $output ~= $chunk;
-        $stdout ~= $chunk;
-    });
-    $proc.stderr.tap(-> $chunk {
-        print $chunk;
-        $output ~= $chunk;
-        $stderr ~= $chunk;
-    });
-    my $p = $proc.start;
-    my $passed = $p.result.exitcode == 0;
+    if $has-proc-async {
+        my $proc = Proc::Async.new(|@command);
+        $proc.stdout.tap(-> $chunk {
+            print $chunk;
+            $output ~= $chunk;
+            $stdout ~= $chunk;
+        });
+        $proc.stderr.tap(-> $chunk {
+            print $chunk;
+            $output ~= $chunk;
+            $stderr ~= $chunk;
+        });
+        my $p = $proc.start;
+        $passed = $p.result.exitcode == 0;
+    }
+    else {
+        my $cmd = @command.map({ qq{"$_"} }).join(' ');
+        $output ~= "$cmd\n";
+        my $p = shell("$cmd 2>&1", :out);
+        for $p.out.lines {
+            .chars && .say;
+            $output ~= "$_\n";
+        }
+        $p.out.close;
+        $passed = $p.exitcode == 0;
+    }
 
     :$output, :$stdout, :$stderr, :$passed
 }

--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -17,23 +17,7 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
 
         if $run-default && 't'.IO ~~ :d {
             withp6lib {
-                my $output = '';
-                my $stdout = '';
-                my $stderr = '';
-
-                my $proc = Proc::Async.new($prove-command, '-e', "$*EXECUTABLE -Ilib", '-r', 't/');
-                $proc.stdout.tap(-> $chunk {
-                    print $chunk;
-                    $output ~= $chunk;
-                    $stdout ~= $chunk;
-                });
-                $proc.stderr.tap(-> $chunk {
-                    print $chunk;
-                    $output ~= $chunk;
-                    $stderr ~= $chunk;
-                });
-                my $p = $proc.start;
-                my $passed = $p.result.exitcode == 0;
+                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($prove-command, '-e', "$*EXECUTABLE -Ilib", '-r', 't/');
 
                 if $bone {
                     $bone.test-output = $output;


### PR DESCRIPTION
Fixes panda on the JVM.

Note that `shell` currently has a bug where it assumes all commands are successful if `:out` is provided, so this should probably not be merged until that has been fixed.