### PR TITLE
Add compatibility with GLR

### DIFF
--- a/lib/Panda.pm
+++ b/lib/Panda.pm
@@ -170,11 +170,11 @@ class Panda {
         }).grep({
             $.ecosystem.project-get-state($_) == Panda::Project::State::absent
         });
-        return () unless +@bonedeps;
+        return Empty unless +@bonedeps;
         self.announce('depends', $bone => @bonedeps».name);
         my @deps;
         for @bonedeps -> $p {
-            @deps.push: self.get-deps($p), $p;
+            @deps.push: flat self.get-deps($p), $p;
         }
         return @deps;
     }

--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -108,7 +108,7 @@ sub run-and-gather-output(*@command) is export {
         $passed = $p.exitcode == 0;
     }
 
-    :$output, :$stdout, :$stderr, :$passed
+    \(:$output, :$stdout, :$stderr, :$passed)
 }
 
 }

--- a/lib/Panda/Ecosystem.pm
+++ b/lib/Panda/Ecosystem.pm
@@ -145,7 +145,7 @@ class Panda::Ecosystem {
         for self.project-list -> $p {
             if any($p.dependencies) eq $name {
                 if !$installed or self.is-installed($p) {
-                    @ret.push: $p, self.revdeps($p, :$installed);
+                    @ret.push: $p, |self.revdeps($p, :$installed);
                 }
             }
         }

--- a/lib/Panda/Installer.pm
+++ b/lib/Panda/Installer.pm
@@ -9,7 +9,7 @@ has $.destdir = self.default-destdir();
 method sort-lib-contents(@lib) {
     my @generated = @lib.grep({ $_ ~~  / \. <{compsuffix}> $/});
     my @rest = @lib.grep({ $_ !~~ / \. <{compsuffix}> $/});
-    return @rest, @generated;
+    return flat @rest, @generated;
 }
 
 # default install location

--- a/t/installer.t
+++ b/t/installer.t
@@ -27,7 +27,7 @@ my @lib = 'foo.pm', 'foo.' ~ compsuffix, 'bam.' ~ compsuffix,
           'bam.pm', 'blaz.pm', 'blaz.' ~ compsuffix, 'shazam.js';
 my @order = Panda::Installer.sort-lib-contents(@lib);
 is-deeply @order,
-          [<foo.pm bam.pm blaz.pm shazam.js>, 
+          [flat <foo.pm bam.pm blaz.pm shazam.js>,
           'foo.' ~ compsuffix, 'bam.' ~ compsuffix, 'blaz.' ~ compsuffix],
           "{compsuffix}s will get installed after rest of the things";
 


### PR DESCRIPTION
Fixed up most cases found by tests and by trying bootstrap.
On my machine, i was able to successfully bootstrap panda on glr given the patched File::Find and Shell::Command deps which i PR'ed on their respective repos. JSON::Tiny has the fixes alredy pushed upstream.