### PR TITLE
Squashed 'ext/File__Find/' changes from 119e620270cb..7a683abb9879

### DIFF
--- a/ext/File__Find/META.info
+++ b/ext/File__Find/META.info
@@ -4,5 +4,23 @@
     "description" : "File::Find for Perl 6",
     "depends"     : [],
     "provides"    : { "File::Find" : "lib/File/Find.pm" },
+    "authors" : [
+        "Tadeusz “tadzik” Sośnierz",
+        "Dagur Valberg Johansson",
+        "Elizabeth Mattijsen",
+        "Filip Sergot",
+        "GlitchMr",
+        "Heather",
+        "isleofmax",
+        "Moritz Lenz",
+        "Paul Cochrane",
+        "Steve Mynott",
+        "timo",
+        "Tobias Leich"
+    ],
+    "support" : {
+        "bugtracker" : "https://github.com/tadzik/File-Find/issues",
+        "source" : "git://github.com/tadzik/File-Find.git"
+    },
     "source-url"  : "git://github.com/tadzik/File-Find.git"
 }

--- a/ext/File__Find/README.md
+++ b/ext/File__Find/README.md
@@ -6,11 +6,22 @@ File::Find - Get a lazy list of a directory tree
 
     use File::Find;
 
+    # recursively (and eagerly) find all files from the 'foo' directory
     my @list := find(dir => 'foo');
     say @list[0..3];
 
+    # the same as above, but lazily return the results
     my $list = find(dir => 'foo');
     say $list[0..3];
+
+    # eagerly find all Perl-related files from the current directory
+    my @perl-files := find(dir => '.', name => /.p [l||m] $/);
+
+    # lazily find all directories within the 'rakudo' directory
+    my $rakudo-dirs = find(dir => 'rakudo', type => 'dir');
+
+    # lazily find all symlinks a normal user can access under `/etc`
+    my $etc-symlinks = find(dir => '/etc/', type => 'symlink', keep-going => True);
 
 ## DESCRIPTION
 
@@ -24,7 +35,7 @@ list of files in given directory. Every element of the list is an
 `find()` takes one (or more) named arguments. The `dir` argument
 is mandatory, and sets the directory `find()` will traverse.
 
-There are also few optional arguments. If more than one is passed,
+There are also a few optional arguments. If more than one is passed,
 all of them must match for a file to be returned.
 
 **name**
@@ -55,7 +66,7 @@ File::Find::Rule, and its features are planned to be similar one day.
 
 ## CAVEATS
 
-List assignment is eager in Perl 6, so if You assign `find()` result
+List assignment is eager in Perl 6, so if you assign `find()` result
 to an array, the elements will be copied and the laziness will be
 spoiled. For a proper lazy list, use either binding (`:=`) or assign
 a result to a scalar value (see SYNOPSIS).

--- a/ext/File__Find/lib/File/Find.pm
+++ b/ext/File__Find/lib/File/Find.pm
@@ -100,6 +100,11 @@ Exclude is meant to be used for skipping certain big and uninteresting
 directories, like '.git'. Neither them nor any of their contents will be
 returned, saving a significant amount of time.
 
+The value of C<exclude> will be smartmatched against each IO object
+found by File::Find. It's recommended that it's passed as an IO object
+(or a Junction of those) so we avoid silly things like slashes
+vs backslashes on different platforms.
+
 =head2 keep-going
 
 Parameter C<keep-going> tells C<find()> to not stop finding files

--- a/ext/File__Find/t/01-file-find.t
+++ b/ext/File__Find/t/01-file-find.t
@@ -42,8 +42,8 @@ equals @test, <t/dir1/file.foo t/dir1/foodir/not_a_dir>,
 	'types: file, combined with name';
 
 #exclude
-my $exclude = $*DISTRO.is-win ?? 't\\dir1\\another_dir' !! 't/dir1/another_dir';
-$res = find(:dir<t/dir1>, :type<file>, :$exclude);
+$res = find(:dir<t/dir1>, :type<file>,
+            :exclude('t/dir1/another_dir'.IO));
 @test = $res.map({ .Str }).sort;
 equals @test, <t/dir1/file.bar t/dir1/file.foo t/dir1/foodir/not_a_dir>, 'exclude works';
 
@@ -68,7 +68,7 @@ if 0 {
 	callsame;
     });
 
-    dies_ok(sub { find(:dir<t/dir1>) },
+    dies-ok(sub { find(:dir<t/dir1>) },
         "dies due to X::IO::Dir");
 
     $throw = $skip-first = True;


### PR DESCRIPTION
7a683abb9879 Merge pull request #11 from flussence/master
ae88ab4fb768 Kebab-case dies_ok to fix deprecation
8c39dec86874 Merge pull request #10 from paultcochrane/pr/expand-readme-synopsis
c3e30d319099 Add examples of the name, type and keep-going options to SYNOPSIS
15277eea7f75 Add comments explaining SYNOPSIS examples
8907c618610e Fix minor typos in README.md
034d8e24c715 Fill in META.info
522363b2ac2b Specify what exactly exclude should be and how it's handled

git-subtree-dir: ext/File__Find
git-subtree-split: 7a683abb9879738d671eb5a09923096a429eeda7