### PR TITLE
Feature/update json fast

### DIFF
--- a/ext/JSON__Fast/t/03-unicode.t
+++ b/ext/JSON__Fast/t/03-unicode.t
@@ -8,9 +8,14 @@ my @t =
     '{ "a" : "b\u00E5" }' => { 'a' => 'bå' },
     '[ "\u2685" ]' => [ '⚅' ];
 
+my @out = 
+    "\{\"a\": \"bå\"}",
+    '["⚅"]';
+
 plan (+@t * 2);
+my $i = 0;
 for @t -> $p {
     my $json = from-json($p.key);
     is-deeply $json, $p.value, "Correct data structure for «{$p.key}»";
-    is to-json($json).lc, $p.key.lc;
+    is to-json($json, :pretty(False)).lc, @out[$i++].lc, 'to-json test';
 }

--- a/ext/JSON__Fast/t/04-roundtrip.t
+++ b/ext/JSON__Fast/t/04-roundtrip.t
@@ -7,7 +7,7 @@ my @s =
         'Rat'            => [ 3.2 ],
         'Str'            => [ 'one' ],
         'Str with quote' => [ '"foo"'],
-        'Undef'          => [ Any, 1 ],
+        'Undef'          => [ {}, 1 ],
         'other escapes'  => [ "\\/\"\n\r\tfoo\\"],
         'Non-ASCII'      => [ 'möp stüff' ],
         'Empty Array'    => [ ],
@@ -33,8 +33,7 @@ my @s =
 plan +@s;
 
 for @s.kv -> $k, $v {
-    #warn "The json is <{ to-json( .value ) }>";
-    my $r = from-json( to-json( $v.value ) );
+    my $r = from-json( to-json( $v.value, :!pretty ) );
     todo('known type mismatches') if $k == 9;
     is-deeply $r, $v.value, $v.key;
 }

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -130,7 +130,7 @@ method bundle($panda, :$notests, Str :$name, Str :$auth, Str :$ver, Str :$desc) 
             support        => {
                 source => ~$bone.metainfo<source-url>,
             }
-        }) ~ "\n";
+        }, :pretty) ~ "\n";
 
         CATCH {
             try unlink %*ENV<PANDA_DEPTRACKER_FILE> if %*ENV<PANDA_DEPTRACKER_FILE>.IO.e;

--- a/lib/Panda/Ecosystem.pm
+++ b/lib/Panda/Ecosystem.pm
@@ -31,7 +31,7 @@ class Panda::Ecosystem {
     method flush-states {
         my $fh = open($!statefile, :w);
         for %!states.kv -> $key, $val {
-            my $json = to-json %!saved-meta{$key};
+            my $json = to-json %!saved-meta{$key}, :!pretty;
             $fh.say: "$key {$val.Str} $json";
         }
         $fh.close;

--- a/lib/Panda/Reporter.pm
+++ b/lib/Panda/Reporter.pm
@@ -96,7 +96,7 @@ method to-json {
             :precomp-target($*VM.precomp-target),
             :prefix($*VM.prefix.Str),
         }),
-    }
+    }, :pretty;
 }
 
 }


### PR DESCRIPTION
Hi,

Now JSON::Fast emits a pretty json by default. See https://github.com/timo/json_fast/pull/2
This breaks panda's state file as described in #212.

This PR updates JSON::Fast git subtree and explicitly passes `:pretty` or `:!pretty` to `to-json()` function so that panda's state file works.
