### PR TITLE
grep now uses single-arg-rule slurpy

### DIFF
--- a/bootstrap.pl
+++ b/bootstrap.pl
@@ -18,7 +18,7 @@ sub MAIN(Str :$prefix is copy) {
 
     my $panda-base;
     $prefix = "$CWD/$prefix" if defined($prefix) && $is_win && $prefix !~~ /^ '/' /;
-    for grep(*.defined, $prefix, %*CUSTOM_LIB<site home>) -> $target {
+    for grep(*.defined, flat $prefix, %*CUSTOM_LIB<site home>) -> $target {
         $prefix = $target;
         $panda-base = "$target/panda";
         try mkdir $prefix;


### PR DESCRIPTION
Without this change, bootstrap.pl dies with:

Type check failed in assignment to '$prefix'; expected 'Str' but got 'List'
  in sub MAIN at bootstrap.pl:22
  in block <unit> at bootstrap.pl:7

Since https://github.com/rakudo/rakudo/commit/63a883fcce