### PR TITLE
Fix "panda" with no args to display usage

### DIFF
--- a/bin/panda
+++ b/bin/panda
@@ -88,7 +88,7 @@ multi MAIN ('look', *@modules, Str :$prefix) {
     }
 }
 
-multi MAIN (*@modules, Bool :$notests, Bool :$nodeps, Str :$prefix) {
+multi MAIN (Bool :$notests, Bool :$nodeps, Str :$prefix, *@modules where * > 0) {
     MAIN('install', @modules, :$notests, :$nodeps)
 }
 


### PR DESCRIPTION
Slurpy parameters should follow optional parameters. Constraint slurpy to exist so that typing "panda" on its own returns usage rather than nothing.