### PR TITLE
Add $where to @INC rather than . if Build.pm exists

### DIFF
--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -5,7 +5,7 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
     indir $where, {
         my Bool $run-default = True;
         if "Build.pm".IO.f {
-            @*INC.push('file#.');   # TEMPORARY !!!
+            @*INC.push("file#$where");   # TEMPORARY !!!
             GLOBAL::<Build>:delete;
             require 'Build.pm';
             if ::('Build').isa(Panda::Tester) {


### PR DESCRIPTION
This matches the usage in Builder.pm
It seems that the test stage could fail if Build.pm exists in $where
when doing a bootstrap e.g:

Could not find file 'Build.pm' for module Build.pm
  in block  at
/home/jonathan/.rakudobrew/moar-nom/install/share/perl6/site/lib/Panda/Tester.pm:10
  in sub indir at
/home/jonathan/.rakudobrew/moar-nom/install/share/perl6/site/lib/Panda/Common.pm:20