### PR TITLE
use JSON::Fast::to-json entirely

### DIFF
--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -2,6 +2,7 @@ class Panda::Bundler {
 use Panda::Common;
 use Panda::Project;
 use File::Find;
+use JSON::Fast;
 
 sub guess-project($where, Str :$name is copy, Str :$desc is copy) {
     my $source-url;

--- a/lib/Panda/Reporter.pm
+++ b/lib/Panda/Reporter.pm
@@ -1,5 +1,5 @@
 class Panda::Reporter {
-
+use JSON::Fast;
 has $.bone is rw;
 has $.reports-file is rw;
 


### PR DESCRIPTION
This PR will fix #222 (`Unexpected named parameter 'pretty' passed`), which was introduced by my previous PR #214. Sorry...

In #214, I didn't realize that panda used two different to-json() functions, rakudo core to-json() and JSON::Fast::to-json().

I think we should use one of them, and rakudo core to-json() does not support one-line json.
So this PR changes the code to use JSON::Fast::to-json entirely.