### PR TITLE
Add `--norc` option into `prove` command that is used on Panda::Tester

### DIFF
--- a/lib/Panda/Tester.pm
+++ b/lib/Panda/Tester.pm
@@ -21,7 +21,7 @@ method test($where, :$bone, :$prove-command = $*DISTRO.name eq 'mswin32' ?? 'pro
                 for @deps -> $lib {
                     $libs ~= ' -M' ~ $lib;
                 }
-                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($prove-command, '-e', "$*EXECUTABLE $libs -Ilib", '-r', 't/');
+                my ( :$output, :$stdout, :$stderr, :$passed ) := run-and-gather-output($prove-command, '-e', "$*EXECUTABLE $libs -Ilib", "--norc", '-r', 't/');
 
                 if $bone {
                     $bone.test-output = $output;


### PR DESCRIPTION
`t/tester.t` will be failed if `--verbose` or `--failures` option
is written in `.proverc`, because Panda::Tester uses `prove` through
command execution.

That command execution uses `.proverc` implicitly, so it is necessary
to be disable that in order to make tests successful.

So added `--norc` option into prove command.