### PR TITLE
Improve bin/panda USAGE and invalid arguments

### DIFF
--- a/bin/panda
+++ b/bin/panda
@@ -92,6 +92,53 @@ multi MAIN (Bool :$notests, Bool :$nodeps, Str :$prefix, *@modules where * > 0) 
     MAIN('install', @modules, :$notests, :$nodeps)
 }
 
+sub USAGE {
+    note q:to/END_USAGE/;
+Panda -- Perl 6 Module Installer
+
+Usage:
+    panda <action> [options]
+
+Common options:
+    --prefix=/path/to/modules    Place to put modules, executable scripts, etc.
+
+Actions:
+    install        Installs the modules listed on the command line, and their
+                   dependencies.
+        --notests    Don't run tests for the modules being installed.
+        --nodeps     Skip installing modules' dependencies.
+
+    installdeps    Installs the dependencies of the listed modules, but not the
+                   modules themselves.
+        --notests    Don't run tests for the dependencies being installed.
+
+    list           Lists all the modules available.
+        --verbose      Provide verbose output
+        --installed    List only installed modules
+
+    update         Updates the local copy of the module database.
+
+    info           Lists information available on given modules.
+
+    search         Searches the database for module names/descriptions matching
+                   the given substring.
+
+    gen-meta       Generates a META.info with supplied options (see below).
+        --notests          Specifies that the module whose META.info is being
+                           generated doesn't have tests(?)
+        --name=A::Name     Specify the module's name
+        --auth=JRandom     Specify the author's name
+        --ver=v0.1         Specify the module version
+        --desc="A desc"    Specify the module description
+
+    smoke          Tests and installs all packages. (Not for typical use.)
+        --exclude=A::Name    Specifies a package to skip testing.
+
+    look           Downloads and unpacks the listed modules, afterwards going to
+                   them with your shell.
+END_USAGE
+}
+
 END {
     rm_rf '.panda-work' if '.panda-work'.IO.e;
 

--- a/bin/panda
+++ b/bin/panda
@@ -88,12 +88,15 @@ multi MAIN ('look', *@modules, Str :$prefix) {
     }
 }
 
+#| prints USAGE and exits
+multi sub MAIN('help') { USAGE }
+
 multi MAIN (Bool :$notests, Bool :$nodeps, Str :$prefix, *@modules where * > 0) {
     MAIN('install', @modules, :$notests, :$nodeps)
 }
 
 sub USAGE {
-    note q:to/END_USAGE/;
+    note q:to/END_USAGE/.chomp; # 'note' adds a newline, so get rid of heredoc's
 Panda -- Perl 6 Module Installer
 
 Usage:
@@ -136,6 +139,10 @@ Actions:
 
     look           Downloads and unpacks the listed modules, afterwards going to
                    them with your shell.
+
+'list', 'update', and 'smoke' don't take a list of module names to
+install. 'search' takes a string to search case-insensitively for in the
+database.
 END_USAGE
 }
 

--- a/bin/panda
+++ b/bin/panda
@@ -91,10 +91,6 @@ multi MAIN ('look', *@modules, Str :$prefix) {
 #| prints USAGE and exits
 multi sub MAIN('help') { USAGE }
 
-multi MAIN (Bool :$notests, Bool :$nodeps, Str :$prefix, *@modules where * > 0) {
-    MAIN('install', @modules, :$notests, :$nodeps)
-}
-
 sub USAGE {
     note q:to/END_USAGE/.chomp; # 'note' adds a newline, so get rid of heredoc's
 Panda -- Perl 6 Module Installer


### PR DESCRIPTION
These commits add a custom `&USAGE` for panda to use (whose organization, formatting, etc. can be modified as necessary, this is just what I came up with for a more verbose/helpful `USAGE`), adds the `help` action for printing the `USAGE`, and removes the `panda module::name` → `panda install module::name` shortcut.

The last one, removing the `install` shortcut, is so that attempted actions that don't exist will produce a help message, instead of thinking it's a package (before the commit adding the `help` action, trying `panda help` caused panda to try to install a package named `help`). The alternative could've been to require actions written as `--install`, `--installdeps`, etc. (or some other prefix/suffix), but that would have caused more issues in terms of changed syntax.