### PR TITLE
Fix #112: .bat launchers for Win32 environment

### DIFF
--- a/lib/Panda/Installer.pm
+++ b/lib/Panda/Installer.pm
@@ -72,6 +72,25 @@ method install($from, $to? is copy, Panda::Project :$bone) {
                     mkpath "$to/{$bin.dirname}";
                     copy($bin, "$to/$bin");
                     "$to/$bin".IO.chmod(0o755) unless $*DISTRO.is-win;
+
+                    # TODO remove this once CompUnit installation actually works
+                    "$to/$bin.bat".IO.spurt(q:to[SCRIPT]
+@rem = '--*-Perl-*--
+@echo off
+if "%OS%" == "Windows_NT" goto WinNT
+perl6 "%~dpn0" %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto endofperl
+:WinNT
+perl6 "%~dpn0" %*
+if NOT "%COMSPEC%" == "%SystemRoot%\system32\cmd.exe" goto endofperl
+if %errorlevel% == 9009 echo You do not have Perl in your PATH.
+if errorlevel 1 goto script_failed_so_exit_with_non_zero_val 2>nul
+goto endofperl
+@rem ';
+__END__
+:endofperl
+SCRIPT
+                    );
                 }
             }
         }


### PR DESCRIPTION
This is an attempt at fixing panda situation on windows because of the missing .bat file.