### PR TITLE
options have to precede actions now

### DIFF
--- a/bin/panda
+++ b/bin/panda
@@ -96,7 +96,7 @@ sub USAGE {
 Panda -- Perl 6 Module Installer
 
 Usage:
-    panda <action> [options]
+    panda [options] <action> 
 
 Common options:
     --prefix=/path/to/modules    Place to put modules, executable scripts, etc.


### PR DESCRIPTION
17:16] < stmuk_> Usage: panda <action> [options]
[17:17] < stmuk_> but I have to do panda --notests install 007
[17:17] < stmuk_> I think it should be Usage: panda [options] <action>?
