### PR TITLE
Add MONKEY-SEE-NO-EVAL pragma to access EVAL after change today

### DIFF
--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -3,6 +3,7 @@ use Panda::Common;
 use Panda::Project;
 use File::Find;
 use JSON::Fast;
+use MONKEY-SEE-NO-EVAL;
 
 sub guess-project($where, Str :$name is copy, Str :$desc is copy) {
     my $source-url;


### PR DESCRIPTION
TimToady wrote https://github.com/rakudo/rakudo/commit/625d1c5116 today.  With that, Panda breaks at compile time without access to EVAL.  This restores it.  The pragma could maybe be lexically scoped more, but file scope looked fine to me.