### PR TITLE
try to unconditionally make $pandadir via .mkdir instead of &mkpath

### DIFF
--- a/lib/Panda/App.pm
+++ b/lib/Panda/App.pm
@@ -12,7 +12,7 @@ sub make-default-ecosystem(Str $prefix? is copy) is export {
     for grep(*.defined, flat $prefix, @custom-lib) -> $target {
         $prefix  = $target;
         $pandadir = "$target/panda".IO;
-        try mkpath $pandadir unless $pandadir ~~ :d;
+        try $pandadir.mkdir;
         last if $pandadir.w;
     }
     unless $pandadir.w {


### PR DESCRIPTION
`mkdir` on MoarVM already does the same thing as `mkpath` and does not fail in case of preexisting directories, so no need to check beforehand.

Fixes @mojca issues according to http://irclog.perlgeek.de/perl6/2015-12-30#i_11800996

Supersedes #264 