### PR TITLE
Apply :$force change to installdeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ blib/*
 lib/*.pir
 Makefile
 *~
+.precomp

--- a/bin/panda
+++ b/bin/panda
@@ -22,10 +22,10 @@ multi MAIN ('install', *@modules, Bool :$notests, Bool :$nodeps, Bool :$force = 
 }
 
 #| Install dependencies, but don't build the modules themselves
-multi MAIN ('installdeps', *@modules, Bool :$notests, Str :$prefix) {
+multi MAIN ('installdeps', *@modules, Bool :$notests, Bool :$force = False, Str :$prefix) {
     my $panda = Panda.new(:ecosystem(make-default-ecosystem($prefix)));
     for @modules -> $x {
-        $panda.resolve($x, :$notests, :action<install-deps-only>,
+        $panda.resolve($x, :$notests, :action<install-deps-only>, :$force,
                        :$prefix);
         CATCH { when X::Panda { %failed{$x}.push($_) && say $_ } };
     }


### PR DESCRIPTION
Should fix "cannot unbox type object" with installdeps.  This is basically the same as that for install but actually adds "force" to the installdeps which is possibly useful anyway.