### PR TITLE
Fix File::Find installation problems

### DIFF
--- a/lib/Panda/App.pm
+++ b/lib/Panda/App.pm
@@ -7,6 +7,10 @@ use Panda::Project;
 sub make-default-ecosystem(Str $prefix? is copy) is export {
     my $custom-prefix = ?$prefix;
     my $pandadir;
+    if defined($prefix) && $prefix ~~ /^ 'inst#' (.*) / {
+        my $repo = CompUnit::RepositoryRegistry.repository-for-spec($prefix);
+        $prefix = $repo.prefix.Str if $repo;
+    }
     $prefix = "$*CWD/$prefix" if defined($prefix) && !$*DISTRO.is-win && $prefix !~~ /^ '/' /;
     my @custom-lib = <site home>.map({CompUnit::RepositoryRegistry.repository-for-name($_)}).grep(*.defined).map(*.prefix.Str);
     for grep(*.defined, flat $prefix, @custom-lib) -> $target {


### PR DESCRIPTION
Currently, if you try to install a module that directly or indirectly
requires File::Find or other panda-required modules, panda will not
recognize that those modules were already installed in the bootstrapping
process.  As a result, unless `--force` is specified, the installation
will fail complaining that File::Find has already been installed.  In
addition, a directory hierarchy is created in the panda working
directory during bootstrapping under inst#, which causes other issues
when bootstrapping from the same working directory in the future.

This is because a stringy representation of a CompUnit repo is
improperly detected as a relative path, and we end up with a sort of
"split" repository between the actual install prefix and the one under
`$panda_working_dir/#inst`; the actual modules are installed under
the installation prefix, but the panda state is written under
`$panda_working_dir/#inst`.

This commit detects installation compunit repos (by checking for inst#)
and does the right thing when they are present.