### PR TITLE
fixes an odd bug where it tries to install in an invalid directory

### DIFF
--- a/bootstrap.pl
+++ b/bootstrap.pl
@@ -23,7 +23,7 @@ sub MAIN(Str :$prefix is copy) {
     my @custom-lib = <site home>.map({CompUnit::RepositoryRegistry.repository-for-name($_)});
     for grep(*.defined, flat $prefix, @custom-lib, @repos) -> $target {
         if $target ~~ CompUnit::Repository {
-            $prefix = $target.path-spec;
+            $prefix = "{$target.prefix}";
             $repo   = $prefix;
             $panda-base = "{$target.prefix}/panda";
             try mkdir $panda-base unless $panda-base.IO.d;


### PR DESCRIPTION
target.path-spec returns a weird string like "inst#/home/user/.rakudobrow........", which results in many problems