### PR TITLE
clean up pathspec prefix for human readable instructions

### DIFF
--- a/bootstrap.pl
+++ b/bootstrap.pl
@@ -63,6 +63,7 @@ sub MAIN(Str :$prefix is copy) {
 
     my $prefix_str = $prefix ?? "--prefix=$prefix" !! '';
     shell "$*EXECUTABLE --ll-exception bin/panda --force $prefix_str install $*CWD";
+    $prefix.=subst(/^inst\#/,"");
     say "==> Please make sure that $prefix/bin is in your PATH";
 
     unlink "$panda-base/projects.json";


### PR DESCRIPTION
clean up pathspec prefix for human readable instructions.  otherwise you end up with a slightly confusing instruction like:

==> Installing panda
==> Successfully installed panda
==> Please make sure that inst#/home/dale/.rakudobrew/moar-nom/install/share/perl6/site/bin is in your PATH