### PR TITLE
Use prefix when installing deps

### DIFF
--- a/lib/Panda.pm
+++ b/lib/Panda.pm
@@ -211,7 +211,7 @@ class Panda {
                 $.ecosystem.project-get-state($_)
                     == Panda::Project::absent
             };
-            self.install($_, $nodeps, $notests, 1, :$force) for @deps;
+            self.install($_, $nodeps, $notests, 1, :$prefix, :$force) for @deps;
         }
 
         given $action {


### PR DESCRIPTION
`--prefix` options doesn't get pased to the install for deps. For normal install it works correctly.

Before:
```
$ rm -rf here; mkdir here
$ panda --prefix="inst#here" installdeps .
==> Test depends on Acme::Meow
==> Fetching Acme::Meow
==> Building Acme::Meow
==> Testing Acme::Meow
t/00-load.t .. ok
t/01-fun.t ... ok
All tests successful.
Files=2, Tests=7,  2 wallclock secs ( 0.02 usr  0.00 sys +  1.98 cusr  0.13 csys =  2.13 CPU)
Result: PASS
==> Installing Acme::Meow
==> Successfully installed Acme::Meow
$ tree here
here
└── panda
    ├── projects.json
    └── state

1 directory, 2 files
```

After:
```
$ rm -rf here; mkdir here
$ panda --prefix="inst#here" installdeps .
==> Test depends on Acme::Meow
==> Fetching Acme::Meow
==> Building Acme::Meow
==> Testing Acme::Meow
t/00-load.t .. ok
t/01-fun.t ... ok
All tests successful.
Files=2, Tests=7,  2 wallclock secs ( 0.02 usr  0.00 sys +  2.03 cusr  0.14 csys =  2.19 CPU)
Result: PASS
==> Installing Acme::Meow
==> Successfully installed Acme::Meow
$ tree here
here
├── bin
├── dist
│   └── F15BE61835E63CD5C7103F80A8B92AF85AA9EA95
├── panda
│   ├── projects.json
│   └── state
├── repo.lock
├── resources
├── short
│   └── 7EECB474A4B076F9ADC69FA64009364FC2824DBE
└── sources
    └── 4E9BDFC55D26E09C9E7088F6F534B7FBB9028A51

6 directories, 6 files
```