### PR TITLE
add extra statefiles from @repos under consideration

### DIFF
--- a/lib/Panda/App.pm
+++ b/lib/Panda/App.pm
@@ -25,7 +25,7 @@ sub make-default-ecosystem(Str $prefix?) is export {
 
     my @extra-statefiles;
     unless $prefix or $target eq CompUnit::RepositoryRegistry.repository-for-name('site') {
-        for @repos {
+        for $*REPO.repo-chain.grep(CompUnit::Repository::Installable) {
             unless $target eq $_ {
                 @extra-statefiles.push($_.prefix.child('panda').child('state'));
             }

--- a/lib/Panda/App.pm
+++ b/lib/Panda/App.pm
@@ -27,7 +27,7 @@ sub make-default-ecosystem(Str $prefix?) is export {
     unless $prefix or $target eq CompUnit::RepositoryRegistry.repository-for-name('site') {
         for @repos {
             unless $target eq $_ {
-                @extra-statefiles.push($target.prefix.child('panda').child('state'));
+                @extra-statefiles.push($_.prefix.child('panda').child('state'));
             }
         }
     }


### PR DESCRIPTION
This looks like a copy-paste artifact introduced at aa89bca25ef7c0f1208a6af81364c9a64d68e710. For each `@repos` entry, the code would add the same statefile (located under $target). That is already the main statefile. 

The result is that when panda is installing to home repo (eg. site repo is not writable), the site repo statefile is not used. I believe the purpose of the original code was to read statefile from "other" repos too, in this case. Ie. Panda tries installdeps to home repo, even it a modules is already installed to site repo.
