### PR TITLE
send smoke reports JSON as strict utf-8

### DIFF
--- a/lib/Panda/Reporter.pm
+++ b/lib/Panda/Reporter.pm
@@ -28,8 +28,8 @@ method submit {
             $to-send = "POST http://testers.perl6.org/report HTTP/1.1\nHost: testers.perl6.org\nConnection: Close";
         }
 
-        my $buf = Buf.new(self.to-json.ords);
-        $s.print("$to-send\nContent-Type: application/json\r\nContent-Length: $buf.elems()\r\n\r\n");
+        my utf8 $buf = self.to-json.encode("utf-8");
+        $s.print("$to-send\nContent-Type: application/json; ; charset=utf-8\r\nContent-Length: $buf.elems()\r\n\r\n");
         $s.write($buf);
 
         my $report-id = '';


### PR DESCRIPTION
utf-8

This fixes the current breakage of smoke reports for Compress::Zlib::Raw and downstream
modules:

```
PANDA_SUBMIT_TESTREPORTS=1 perl6 -I ../panda/lib/ ../panda/bin/panda --force --notests install Compress::Zlib::Raw
==> Fetching Compress::Zlib::Raw
==> Building Compress::Zlib::Raw
Found system zlib library.
==> Installing Compress::Zlib::Raw
Potential difficulties:
    In 'deflateBound' routine declaration - Not an accepted NativeCall type for parameter [2]  : int
     --> For Numerical type, use the appropriate int32/int64/num64...
    at /home/david/git/rakudo/install/share/perl6/site/sources/FE992CD05870773DBDC05495667F45237164C142:155
    ------> ong is native(&find-lib) is export { * }⏏<EOL>
... # etc
==> Test report submitted as: http://testers.perl6.org/reports/invalid character encountered while parsing JSON string, at character offset 13827 (before "\x{1b}[32mong is nat...") at /home/testers.perl6.org/FlightRecorder/bin/app.pl line 14..html