### PR TITLE
Add the --version command line flag

### DIFF
--- a/bin/panda
+++ b/bin/panda
@@ -88,6 +88,12 @@ multi MAIN ('look', *@modules, Str :$prefix) {
     }
 }
 
+#| print version information and exit
+multi sub MAIN(Bool :$version, Str :$prefix) {
+    my $panda = Panda.new(:ecosystem(make-default-ecosystem($prefix)));
+    say $panda.version;
+}
+
 #| prints USAGE and exits
 multi sub MAIN('help') { USAGE }
 multi sub MAIN(Bool :$help) { USAGE }
@@ -106,6 +112,7 @@ Examples:
 Common options:
     --prefix=/path/to/modules    Place to put modules, executable scripts, etc.
     --help                       Print the help/usage text.
+    --version                    Print version information and exit.
 
 Actions:
     install        Installs the modules listed on the command line, and their

--- a/lib/Panda.pm
+++ b/lib/Panda.pm
@@ -237,6 +237,27 @@ class Panda {
             when 'look'    { self.look($bone) };
         }
     }
+
+    method version {
+        my $version;
+
+        if '.git'.IO.e {
+            $version = qx{git describe --tags}.chomp;
+        }
+        elsif %?RESOURCES.repo {
+            # read version from META.info (a bit hacky, but works)
+            my $repo = %?RESOURCES.repo;
+            my $lib-path = $repo.subst(/ ^ 'file#' /, '');
+            my $metafile = $*SPEC.catdir($lib-path.IO, '..', 'META.info');
+            my %meta = from-json slurp $metafile;
+            $version = %meta<version>;
+        }
+        else {
+            $version = "unknown";
+        }
+
+        return $version;
+    }
 }
 
 # vim: ft=perl6

--- a/t/commands-options.t
+++ b/t/commands-options.t
@@ -1,0 +1,21 @@
+use v6;
+
+use Test;
+use lib 'lib';
+
+plan 2;
+
+use-ok "Panda";
+use Panda;
+use Panda::App;
+
+subtest {
+    plan 2;
+
+    my $panda = Panda.new(:ecosystem(make-default-ecosystem()));
+    can-ok($panda, 'version');
+
+    ok $panda.version, "version returns at least *something*";
+}, "--version gives version info";
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
This adds a new method to the Panda class called `version` which, if in a
git working directory determines the version from the most recent tag via
`git describe` otherwise it tries to extract the version information from
`META.info`.  At present the solution is a bit hacky, however as soon as
information can be extracted from the DISTRIBUTION variable, the
implementation can be improved.  This commit thus closes issue #204 and by
inference also issue #198.
