### PR TITLE
make `panda gen-meta` works even if there's no META file exists

### DIFF
--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -10,7 +10,7 @@ sub guess-project($where, Str :$name is copy, Str :$desc is copy) is export {
 
     indir $where, {
         my $metafile = find-meta-file(".");
-        if $metafile.IO.e {
+        if $metafile.defined && $metafile.IO.e {
             try my $json = from-json $metafile.IO.slurp;
             if $json {
                 $name       = $json<name>        if !$name && $json<name>;

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -5,7 +5,7 @@ use File::Find;
 use JSON::Fast;
 use MONKEY-SEE-NO-EVAL;
 
-sub guess-project($where, Str :$name is copy, Str :$desc is copy) is export {
+sub guess-project($where, Str :$name is copy, Str :$desc is copy) is export(:ALL) {
     my $source-url;
 
     indir $where, {

--- a/lib/Panda/Bundler.pm
+++ b/lib/Panda/Bundler.pm
@@ -5,7 +5,7 @@ use File::Find;
 use JSON::Fast;
 use MONKEY-SEE-NO-EVAL;
 
-sub guess-project($where, Str :$name is copy, Str :$desc is copy) {
+sub guess-project($where, Str :$name is copy, Str :$desc is copy) is export {
     my $source-url;
 
     indir $where, {

--- a/t/bundler.t
+++ b/t/bundler.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use Panda::Bundler;
+use Panda::Bundler :ALL;
 
 plan 11;
 

--- a/t/bundler.t
+++ b/t/bundler.t
@@ -1,0 +1,17 @@
+use v6;
+use Test;
+use Panda::Bundler;
+
+plan 6;
+
+my $repo_dir_with_meta = 'testmodules/with-META-info-supplied';
+
+my $proj_with_meta = guess-project($repo_dir_with_meta);
+ok $proj_with_meta.name eq "Example", 'name specified in META.info';
+ok $proj_with_meta.metainfo{'description'} eq "an example module", 'desc specified in META.info';
+ok $proj_with_meta.metainfo{'source-url'} eq "git://github.com/astj/nosuchrepo.git", 'source-url specified in META.info';
+
+my $proj_with_override = guess-project($repo_dir_with_meta, :name("OverRideName"), :desc("OverRideDescription"));
+ok $proj_with_override.name eq "OverRideName", 'Prefer specified name rather than META.info';
+ok $proj_with_override.metainfo{'description'} eq "OverRideDescription", 'Prefer specifed description rather than META.info';
+ok $proj_with_override.metainfo{'source-url'} eq "git://github.com/astj/nosuchrepo.git", 'source-url specified in META.info';

--- a/t/bundler.t
+++ b/t/bundler.t
@@ -2,16 +2,26 @@ use v6;
 use Test;
 use Panda::Bundler;
 
-plan 6;
+plan 11;
 
 my $repo_dir_with_meta = 'testmodules/with-META-info-supplied';
 
-my $proj_with_meta = guess-project($repo_dir_with_meta);
+my $proj_with_meta;
+lives-ok { $proj_with_meta = guess-project($repo_dir_with_meta); };
 ok $proj_with_meta.name eq "Example", 'name specified in META.info';
 ok $proj_with_meta.metainfo{'description'} eq "an example module", 'desc specified in META.info';
 ok $proj_with_meta.metainfo{'source-url'} eq "git://github.com/astj/nosuchrepo.git", 'source-url specified in META.info';
 
-my $proj_with_override = guess-project($repo_dir_with_meta, :name("OverRideName"), :desc("OverRideDescription"));
+my $proj_with_override;
+lives-ok { $proj_with_override = guess-project($repo_dir_with_meta, :name("OverRideName"), :desc("OverRideDescription")); };
 ok $proj_with_override.name eq "OverRideName", 'Prefer specified name rather than META.info';
 ok $proj_with_override.metainfo{'description'} eq "OverRideDescription", 'Prefer specifed description rather than META.info';
 ok $proj_with_override.metainfo{'source-url'} eq "git://github.com/astj/nosuchrepo.git", 'source-url specified in META.info';
+
+
+my $repo_dir_without_meta = 'testmodules/dummymodule';
+
+my $proj_without_meta_with_override;
+lives-ok { $proj_without_meta_with_override = guess-project($repo_dir_without_meta, :name("OverRideName"), :desc("OverRideDescription")); }, 'Can guess project even META.info is not exists';
+ok $proj_without_meta_with_override.name eq "OverRideName", 'Prefer specified name rather than META.info';
+ok $proj_without_meta_with_override.metainfo{'description'} eq "OverRideDescription", 'Prefer specifed description rather than META.info';

--- a/testmodules/with-META-info-supplied/META.info
+++ b/testmodules/with-META-info-supplied/META.info
@@ -1,0 +1,17 @@
+{
+  "name": "Example",
+  "support": {
+  },
+  "perl": "v6",
+  "build-depends": [
+  ],
+  "provides": {
+  },
+  "depends": [
+  ],
+  "test-depends": [
+  ],
+  "description": "an example module",
+  "version": "v0.0",
+  "source-url" : "git://github.com/astj/nosuchrepo.git"
+}


### PR DESCRIPTION
Possibly related: #270 

With 56e95bca3711d7972e00329b6725da78f8fa1817, I cannot generate META.info from scratch.
I got following messages:

```
$ panda gen-meta
Must specify something as a path: did you mean '.' for the current directory?
  in sub guess-project at sources/59A561953B2C64A0363F1133A1881A549C2123ED (Panda::Bundler) line 13
  in method bundle at sources/59A561953B2C64A0363F1133A1881A549C2123ED (Panda::Bundler) line 43
  in sub MAIN at /Users/asato/.rakudobrew/moar-nom/install/share/perl6/site/resources/A9B2BCB50A8C400F386FE3E0B32DD101C39F365D line 62
  in block <unit> at /Users/asato/.rakudobrew/moar-nom/install/share/perl6/site/resources/A9B2BCB50A8C400F386FE3E0B32DD101C39F365D line 150
```

This seems a bug, so I tried to fix.
With this patch `panda` can generate `META.info.proposed` even if there're no META files.

(Though there're some warnings remained, they are maybe due to `Panda::DepTracker` is removed at https://github.com/tadzik/panda/commit/a7040f84506d7c4a6988f83ba2d76edccbb42f96 )

```
[github.com/astj/my-p6-sandbox]$ panda gen-meta
==> Building My::P6::Sandbox
==> Testing My::P6::Sandbox
Please enter version number (example: v0.1.0): v0.1.0
==> Creating META.info.proposed
Use of uninitialized value $key of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed.  in block  at sources/7B92510DBBF32725623F9DD418EF96E92FF9EB00 (JSON::Fast) line 39
Use of uninitialized value $key of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed.  in block  at sources/7B92510DBBF32725623F9DD418EF96E92FF9EB00 (JSON::Fast) line 39
Use of uninitialized value of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed.  in block  at sources/7B92510DBBF32725623F9DD418EF96E92FF9EB00 (JSON::Fast) line 39
Use of uninitialized value $key of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed.  in block  at sources/7B92510DBBF32725623F9DD418EF96E92FF9EB00 (JSON::Fast) line 39
Use of uninitialized value $key of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed.  in block  at sources/7B92510DBBF32725623F9DD418EF96E92FF9EB00 (JSON::Fast) line 39
Use of uninitialized value of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed.  in block  at sources/7B92510DBBF32725623F9DD418EF96E92FF9EB00 (JSON::Fast) line 39
[github.com/astj/my-p6-sandbox]$ cat META.info.proposed
{
  "name": "My::P6::Sandbox",
  "support": {
    "source": "ssh://git@github.com/astj/my-p6-sandbox.git"
  },
  "perl": "v6",
  "build-depends": [
    {
      "": true
    }
  ],
  "provides": {
    "": [

    ]
  },
  "depends": [
    {
      "": true
    }
  ],
  "test-depends": [

  ],
  "description": "Unnamed repository; edit this file 'description' to name the repository.\n",
  "version": "v0.1.0"
}
```
