### PR TITLE
Update JSON::Fast to v0.4

### DIFF
--- a/ext/JSON__Fast/META6.json
+++ b/ext/JSON__Fast/META6.json
@@ -2,7 +2,7 @@
   "perl" : "6",
   "name" : "JSON::Fast",
   "description" : "A naive, fast json parser and serializer; drop-in replacement for JSON::Tiny",
-  "version" : "0.3",
+  "version" : "0.4",
   "test-depends" : [
     "Test"
   ],

--- a/ext/JSON__Fast/lib/JSON/Fast.pm
+++ b/ext/JSON__Fast/lib/JSON/Fast.pm
@@ -13,6 +13,7 @@ sub str-escape(str $text) {
 sub to-json($obj is copy, Bool :$pretty = True, Int :$level = 0, Int :$spacing = 2) is export {
     return $obj ?? 'true' !! 'false' if $obj ~~ Bool;
     return $obj.Str if $obj ~~ Int|Rat;
+    return 'null' if not $obj.defined;
     return "\"{str-escape($obj)}\"" if $obj ~~ Str;
 
     if $obj ~~ Seq {

--- a/ext/JSON__Fast/t/04-roundtrip.t
+++ b/ext/JSON__Fast/t/04-roundtrip.t
@@ -2,7 +2,7 @@ use Test;
 
 use JSON::Fast;
 
-my @s =
+my @s = 
         'Int'            => [ 1 ],
         'Rat'            => [ 3.2 ],
         'Str'            => [ 'one' ],
@@ -14,7 +14,9 @@ my @s =
         'Array of Int'   => [ 1, 2, 3, 123123123 ],
         'Array of Num'   => [ 1.3, 2.8, 32323423.4, 4.0 ],
         'Array of Str'   => [ <one two three gazooba> ],
+        'Array of Undef' => [ Any, Any ],
         'Empty Hash'     => {},
+        'Undef Hash Val' => { key => Any },
         'Hash of Int'    => { :one(1), :two(2), :three(3) },
         'Hash of Num'    => { :one-and-some[1], :almost-pie(3.3) },
         'Hash of Str'    => { :one<yes_one>, :two<but_two> },


### PR DESCRIPTION
Hi,
The fix to JSON::Fast was required to allow some of my modules to use it rather than JSON::Tiny, unfortunately this creates a problem as some of the tests will fail with the earlier version that is being installed by panda and it is not possible to get panda to install the newer version as a dependency at the current time.

Thanks.