### PR TITLE
Avoid Rakudo internals deprecation warning

### DIFF
--- a/lib/Panda/Project.pm
+++ b/lib/Panda/Project.pm
@@ -1,4 +1,6 @@
 class Panda::Project {
+    use JSON::Fast;
+    
     has $.name;
     has $.version;
     has @.dependencies;


### PR DESCRIPTION
Building Rakudo head I get the following:

==> Installing panda
==> Successfully installed panda
Saw 1 occurrence of deprecated code.
================================================================================
Sub from-json (from GLOBAL) seen at:
 ~/.rakudobrew/moar-nom/panda/lib/Panda/Project.pm (Panda::Project), line 23
Please use JSON::Fast, JSON::Tiny or JSON::Pretty from https://modules.perl6.org/ instead.
--------------------------------------------------------------------------------
Please contact the author to have these occurrences of deprecated code
adapted, so that this message will disappear!


This appears to follow a refactor to JSON::Fast already underway.