### PR TITLE
Fix warning in Panda::Common

### DIFF
--- a/lib/Panda/Common.pm
+++ b/lib/Panda/Common.pm
@@ -82,7 +82,7 @@ sub run-and-gather-output(*@command) is export {
         });
         my $p = $proc.start;
         # workaround for OSX, see RT125758
-        $p.result;
+        sink $p.result;
         $passed = $p.result.exitcode == 0;
     }
     else {


### PR DESCRIPTION
Add a "sink" for the sink context use of ```$p.result``` thus avoiding the warning.

Fixes #329