### PR TITLE
Add deprecation notice to META description

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "name"        : "panda",
     "version"     : "2016.02",
     "perl"	  : "6.c",
-    "description" : "A module manager",
+    "description" : "[DEPRECATED] A module manager",
     "depends"     : [ "File::Find", "Shell::Command", "JSON::Fast", "File::Which" ],
     "source-url"  : "git://github.com/tadzik/panda.git",
     "license"     : "MIT",


### PR DESCRIPTION
It's already present in README, but this will let it propagate to
modules.perl6.org description as well.